### PR TITLE
Fix CI Builds/SyntaxError

### DIFF
--- a/mlbgame/data.py
+++ b/mlbgame/data.py
@@ -57,18 +57,18 @@ def get_scoreboard(year, month, day):
 def get_box_score(game_id):
     """Return the box score file of a game with matching id."""
     # file
-    local_filename = GAME_PATH.format(*get_date_from_game_id(game_id),
+    local_filename = GAME_PATH.format(*(get_date_from_game_id(game_id),
                                       game_id,
-                                      "boxscore.xml")
+                                      "boxscore.xml"))
     local_file = os.path.join(PWD, local_filename)
     # check if file exits
     if os.path.isfile(local_file):
         return local_file
     # get data if file does not exist
     try:
-        return urlopen(GAME_URL.format(*get_date_from_game_id(game_id),
+        return urlopen(GAME_URL.format(*(get_date_from_game_id(game_id),
                                        game_id,
-                                       "boxscore.xml"))
+                                       "boxscore.xml")))
     except HTTPError:
         raise ValueError("Could not find a game with that id.")
 
@@ -76,18 +76,18 @@ def get_box_score(game_id):
 def get_game_events(game_id):
     """Return the game events file of a game with matching id."""
     # file
-    local_filename = GAME_PATH.format(*get_date_from_game_id(game_id),
+    local_filename = GAME_PATH.format(*(get_date_from_game_id(game_id),
                                       game_id,
-                                      "game_events.xml")
+                                      "game_events.xml"))
     local_file = os.path.join(PWD, local_filename)
     # check if file exits
     if os.path.isfile(local_file):
         return local_file
     # get data if file does not exist
     try:
-        return urlopen(GAME_URL.format(*get_date_from_game_id(game_id),
+        return urlopen(GAME_URL.format(*(get_date_from_game_id(game_id),
                                        game_id,
-                                       "game_events.xml"))
+                                       "game_events.xml")))
     except HTTPError:
         raise ValueError("Could not find a game with that id.")
 
@@ -95,18 +95,18 @@ def get_game_events(game_id):
 def get_overview(game_id):
     """Return the linescore file of a game with matching id."""
     # file
-    local_filename = GAME_PATH.format(*get_date_from_game_id(game_id),
+    local_filename = GAME_PATH.format(*(get_date_from_game_id(game_id),
                                       game_id,
-                                      "linescore.xml")
+                                      "linescore.xml"))
     local_file = os.path.join(PWD, local_filename)
     # check if file exits
     if os.path.isfile(local_file):
         return local_file
         # get data if file does not exist
     try:
-        return urlopen(GAME_URL.format(*get_date_from_game_id(game_id),
+        return urlopen(GAME_URL.format(*(get_date_from_game_id(game_id),
                                        game_id,
-                                       "linescore.xml"))
+                                       "linescore.xml")))
     except HTTPError:
         raise ValueError("Could not find a game with that id.")
 


### PR DESCRIPTION
- This commit fixes the `SyntaxError: only named arguments may follow
*expression` error.
- Tests pass and CI builds cleanly again.