### PR TITLE
Fix GAME_URL bug

### DIFF
--- a/mlbgame/data.py
+++ b/mlbgame/data.py
@@ -17,7 +17,7 @@ except ImportError:
 # Templates For URLS
 BASE_URL = ('http://gd2.mlb.com/components/game/mlb/'
             'year_{0}/month_{1:02d}/day_{2:02d}/')
-GAME_URL = BASE_URL + '/gid_{3}/{4}'
+GAME_URL = BASE_URL + 'gid_{3}/{4}'
 PROPERTY_URL = 'http://mlb.mlb.com/properties/mlb_properties.xml'
 ROSTER_URL = 'http://mlb.mlb.com/lookup/json/named.roster_40.bam?team_id={0}'
 INJURY_URL = 'http://mlb.mlb.com/fantasylookup/json/named.wsfb_news_injury.bam'


### PR DESCRIPTION
This commit fixes issue #50, where the `GAME_URL` contained an extra
`/`, causing an invalid url and triggering the error: `ValueError: Could
not find a game with that id.`.