### PR TITLE
Fix missing dependency on requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     packages=['mlbgame'],
     package_data={'mlbgame': ['default.xml']},
     data_files=[('docs', ['README.md', 'LICENSE', 'description.rst'])],
-    install_requires=['lxml'],
+    install_requires=['lxml', 'requests'],
     extras_require={
         'dev': ['pytest', 'pytest-cov', 'coveralls']
     }


### PR DESCRIPTION
I installed mlbgame in a fresh virtualenv and attempted to use it in the REPL. I got the following error:

```
$ python
Python 2.7.12 (default, Dec  4 2017, 14:50:18)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import mlbgame
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/christian/src/scoreboard/env/local/lib/python2.7/site-packages/mlbgame/__init__.py", line 128, in <module>
    import mlbgame.info
  File "/home/christian/src/scoreboard/env/local/lib/python2.7/site-packages/mlbgame/info.py", line 15, in <module>
    import requests
ImportError: No module named requests
```