### PR TITLE
Add rawboxscore.xml to stats retrieval, fixes #30

### DIFF
--- a/mlbgame/data.py
+++ b/mlbgame/data.py
@@ -51,6 +51,16 @@ def get_box_score(game_id):
     except HTTPError:
         raise ValueError('Could not find a game with that id.')
 
+def get_raw_box_score(game_id):
+    """Return the raw box score file of a game with matching id."""
+    year, month, day = get_date_from_game_id(game_id)
+    try:
+        return urlopen(GAME_URL.format(year, month, day,
+                                       game_id,
+                                       'rawboxscore.xml'))
+    except HTTPError:
+        raise ValueError('Could not find a game with that id.')
+
 
 def get_game_events(game_id):
     """Return the game events file of a game with matching id."""

--- a/mlbgame/stats.py
+++ b/mlbgame/stats.py
@@ -19,10 +19,7 @@ def __player_stats_info(data, name):
             for i in x.attrib:
                 stats[i] = x.attrib[i]
             # apply to correct list
-            if y.attrib['team_flag'] == 'home':
-                home.append(stats)
-            elif not home:
-                away.append(stats)
+            home.append(stats) if y.attrib['team_flag'] == 'home' else away.append(stats)
     return (home, away)
 
 def __raw_player_stats_info(data):


### PR DESCRIPTION
This adds the data retrieved from `rawboxscore.xml` to `player_stats` and `team_stats`. The data is mostly the same but `rawboxscore.xml` contains the groundouts and flyouts for each pitcher, `go` and `ao` respectively.

Why MLB decided it was worth having two XMLs for the box score I'll never know.

Would appreciate code reviews, since I'm not a Python expert.

- [x] Crosscheck #57 and see if it's still an issue. If it requires a larger fix, will be done outside of this PR.
- [x] Log new issue for `stats.py` getting really big. The team stats and player stats can have their own files.