### PR TITLE
Update README to show current output

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ And the output is:
 
     Winning pitcher: Y. Ventura (Royals) - Losing Pitcher: C. Wilson (Angels)
 
-You can easily find stats for the Mets batters
+You can easily print a list of the Mets batters
 in the final game of the 2015 World Series:
 
 ```python
@@ -105,19 +105,18 @@ for player in stats.home_batting:
 
 And the output is:
 
-    Curtis Granderson - 1 for 4 with 1 RBI and 1 Home Runs
-    David Wright - 1 for 5
-    Daniel Murphy - 0 for 3
-    Yoenis Cespedes - 0 for 3
-    Juan Lagares - 0 for 2
-    Lucas Duda - 0 for 2 with 1 RBI
-    Travis d'Arnaud - 0 for 5
-    Michael Conforto - 2 for 5
-    Wilmer Flores - 0 for 4
-    Matt Harvey - 0 for 3
-    Jeurys Familia - 0 for 0
-    Kelly Johnson - 0 for 1
-    Jon Niese - 0 for 0
-    Addison Reed - 0 for 0
-    Bartolo Colon - 0 for 0
-    
+    Curtis Granderson (RF)
+    David Wright (3B)
+    Daniel Murphy (2B)
+    Yoenis Cespedes (CF)
+    Juan Lagares (CF)
+    Lucas Duda (1B)
+    Travis d'Arnaud (C)
+    Michael Conforto (LF)
+    Wilmer Flores (SS)
+    Matt Harvey (P)
+    Jeurys Familia (P)
+    Kelly Johnson (PH)
+    Jonathon Niese (P)
+    Addison Reed (P)
+    Bartolo Colon (P)


### PR DESCRIPTION
This commit updates the example to produce the current output and closes #72. The nice_output method was changed with commit 20d7438. As #72 points out, the output of the sample code doesn't
match the suggested output in the README.