### PR TITLE
Fix GameScoreboard.date

### DIFF
--- a/mlbgame/game.py
+++ b/mlbgame/game.py
@@ -205,15 +205,14 @@ class GameScoreboard(object):
         elif self.away_team_runs > self.home_team_runs:
             self.w_team = self.away_team
             self.l_team = self.home_team
-        # create the datetime object for the game
-        year, month, day = self.game_id.split('_')[0:3]
-        hour, other = self.game_start_time.split(':', 2)
-        minute = other[:2]
-        am_pm = other[2:]
-        if am_pm == 'PM':
-            hour = int(hour) + 11
-        self.date = datetime.datetime(int(year), int(month), int(day),
-                                      int(hour), int(minute))
+        # create a datetime object that represents the game star time
+        # the object has no timezone info but should be interpreted as
+        # being in the US/Eastern timezone
+        year, month, day = self.game_id.split('_')[:3]
+        game_start_date = "/".join([year, month, day])
+        self.date = datetime.datetime.strptime(
+                " ".join([game_start_date, self.game_start_time]),
+                "%Y/%m/%d %I:%M%p")
 
     def nice_score(self):
         """Return a nicely formatted score of the game."""

--- a/mlbgame/game.py
+++ b/mlbgame/game.py
@@ -210,8 +210,9 @@ class GameScoreboard(object):
         # being in the US/Eastern timezone
         year, month, day = self.game_id.split('_')[:3]
         game_start_date = "/".join([year, month, day])
+        game_start_time = self.game_start_time.replace(' ', '')
         self.date = datetime.datetime.strptime(
-                " ".join([game_start_date, self.game_start_time]),
+                " ".join([game_start_date, game_start_time]),
                 "%Y/%m/%d %I:%M%p")
 
     def nice_score(self):

--- a/mlbgame/game.py
+++ b/mlbgame/game.py
@@ -205,7 +205,7 @@ class GameScoreboard(object):
         elif self.away_team_runs > self.home_team_runs:
             self.w_team = self.away_team
             self.l_team = self.home_team
-        # create a datetime object that represents the game star time
+        # create a datetime object that represents the game start time
         # the object has no timezone info but should be interpreted as
         # being in the US/Eastern timezone
         year, month, day = self.game_id.split('_')[:3]

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -44,7 +44,7 @@ class TestGame(unittest.TestCase):
         self.assertEqual(game.away_team_errors, 2)
         self.assertEqual(game.away_team_hits, 6)
         self.assertEqual(game.away_team_runs, 1)
-        self.assertEqual(game.date, datetime(2016, 8, 2, 18, 10))
+        self.assertEqual(game.date, datetime(2016, 8, 2, 19, 10))
         self.assertEqual(game.game_id, '2016_08_02_nyamlb_nynmlb_1')
         self.assertEqual(game.game_league, 'AN')
         self.assertEqual(game.game_start_time, '7:10PM')


### PR DESCRIPTION
I think this is right, although I wonder if the timezone that that `game_start_time` is returned in varies based on where you are requesting the data from (using IP geolocation or something?).

I also updated the test based on the 7:11PM first pitch time reported in the [game box score](https://www.mlb.com/gameday/yankees-vs-mets/2016/08/02/448453?partnerId=LR_box#game_tab=box,game_state=final,game=448453).