### PR TITLE
Don't parse rawboxscore.xml if it doesn't exist

### DIFF
--- a/mlbgame/game.py
+++ b/mlbgame/game.py
@@ -320,20 +320,20 @@ class GameBoxScore(object):
 
 def overview(game_id):
     """Gets the overview information for the game with matching id."""
+    output = {}
     # get data
     overview = mlbgame.data.get_overview(game_id)
-    raw_box_score = mlbgame.data.get_raw_box_score(game_id)
     # parse data
     overview_root = etree.parse(overview).getroot()
-    raw_box_score_root = etree.parse(raw_box_score).getroot()
 
-    output = {}
+    try:
+        output = add_raw_box_score_attributes(output, game_id)
+    except ValueError:
+        pass
+
     # get overview attributes
     for x in overview_root.attrib:
         output[x] = overview_root.attrib[x]
-    # get raw box score attributes
-    for x in raw_box_score_root.attrib:
-        output[x] = raw_box_score_root.attrib[x]
 
     # Get probable starter attributes if they exist
     home_pitcher_tree = overview_root.find('home_probable_pitcher')
@@ -350,6 +350,16 @@ def overview(game_id):
     else:
         output.update(build_probable_starter_defaults('away'))
 
+    return output
+
+
+def add_raw_box_score_attributes(output, game_id):
+    # rawboxscore may not be available prior to a game
+    raw_box_score = mlbgame.data.get_raw_box_score(game_id)
+    raw_box_score_root = etree.parse(raw_box_score).getroot()
+    # get raw box score attributes
+    for attr in raw_box_score_root.attrib:
+        output[attr] = raw_box_score_root.attrib[attr]
     return output
 
 


### PR DESCRIPTION
Fixes #79 

This resurrects @trevor-viljoen's changes from #80 

If possible, would prefer this gets in quickly and tagged, as 2.5.0 currently breaks the LED scoreboard without this change 🔥 