### PR TITLE
Fixes #62

### DIFF
--- a/mlbgame/game.py
+++ b/mlbgame/game.py
@@ -237,10 +237,20 @@ def box_score(game_id):
     # loop through innings and add them to output
     for x in linescore:
         inning = x.attrib['inning']
-        home = x.attrib['home']
-        away = x.attrib['away']
+        home = value_to_int(x.attrib, 'home')
+        away = value_to_int(x.attrib, 'away')
         result[int(inning)] = {'home': home, 'away': away}
     return result
+
+
+def value_to_int(attrib, key):
+    """ Massage runs in an inning to 0 if an empty string,
+    or key not found. Otherwise return the value """
+    val = attrib.get(key, 0)
+    if isinstance(val, str):
+        if val.isspace() or val == '':
+            return 0
+    return val
 
 
 class GameBoxScore(object):
@@ -266,10 +276,11 @@ class GameBoxScore(object):
         # loops through the innings
         for x in sorted(data):
             try:
-                result = {'inning': int(x),
-                          'home': int(data[x]['home']),
-                          'away': int(data[x]['away'])
-                          }
+                result = {
+                    'inning': int(x),
+                    'home': int(data[x]['home']),
+                    'away': int(data[x]['away'])
+                }
             # possible error when 9th innning home team has 'x'
             # becuase they did not bat
             except ValueError:

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -361,3 +361,12 @@ class TestGame(unittest.TestCase):
     def test_players_empty(self):
         self.assertRaises(ValueError, lambda: mlbgame.players('game_id'))
         self.assertRaises(ValueError, lambda: mlbgame.players('2016_08_02_nymlb_nymlb_1'))
+
+    def test_value_to_int(self):
+        attrs = [{'away': ''}, {'not_here': 0}]
+        for attr in attrs:
+            self.assertEqual(0, mlbgame.game.value_to_int(attr, 'away'))
+
+        attrs = [{'home': 3}, {'home': 'X'}]
+        for attr in attrs:
+            self.assertEqual(attr.get('home'), mlbgame.game.value_to_int(attr, 'home'))


### PR DESCRIPTION
This PR is meant to address #62, where a key may not be found in certain game situations.  This adds a function to check for the key. If the key exists and is not an empty string, the value is returned. Otherwise 0 is assumed to be the number of runs scored. 

There are tests for each scenario: 
1. Bot of the 9th: `'X'` for home team.
2. An integer for home or away
3. Key not found
4. An empty string: `''`.