### PR TITLE
Handle invalid XMLSyntaxError on rawboxscore.xml

### DIFF
--- a/mlbgame/game.py
+++ b/mlbgame/game.py
@@ -367,10 +367,13 @@ def overview(game_id):
 def add_raw_box_score_attributes(output, game_id):
     # rawboxscore may not be available prior to a game
     raw_box_score = mlbgame.data.get_raw_box_score(game_id)
-    raw_box_score_root = etree.parse(raw_box_score).getroot()
-    # get raw box score attributes
-    for attr in raw_box_score_root.attrib:
-        output[attr] = raw_box_score_root.attrib[attr]
+    try:
+        raw_box_score_root = etree.parse(raw_box_score).getroot()
+        # get raw box score attributes
+        for attr in raw_box_score_root.attrib:
+            output[attr] = raw_box_score_root.attrib[attr]
+    except etree.XMLSyntaxError:
+        pass
     return output
 
 


### PR DESCRIPTION
Hotfix for 2019 Spring Training. They appear to have stopped adding valid XML data to `rawboxscore.xml`, at least for the first couple days of spring training, so my scoreboard has been bombing when mlbgame tries to parse the XML.

It looks like the directory exists http://gd2.mlb.com/components/game/mlb/year_2019/month_02/day_22/gid_2019_02_22_neubbc_bosmlb_1/rawboxscore.xml

but there's no real XML in there so we don't throw the HTTPError like we do everywhere else, so it fails after trying to parse the tree.