### PR TITLE
Fix error when casting blank literal score as int for ongoing game

### DIFF
--- a/mlbgame/game.py
+++ b/mlbgame/game.py
@@ -275,20 +275,22 @@ class GameBoxScore(object):
         self.innings = []
         # loops through the innings
         for x in sorted(data):
-            try:
-                result = {
-                    'inning': int(x),
-                    'home': int(data[x]['home']),
-                    'away': int(data[x]['away'])
-                }
-            # possible error when 9th innning home team has 'x'
-            # becuase they did not bat
-            except ValueError:
-                result = {
-                    'inning': int(x),
-                    'home': data[x]['home'],
-                    'away': int(data[x]['away'])
-                }
+            # Cast score for each half-inning to `int` if score is a digit
+            # For reference---examples of a blank score ('') appearing:
+            # 1. A team hasn't scored during the half-inning for an ongoing game
+            # 2. Home team does not bat during the bottom of the 9th because they have the lead
+            home_score = data[x]['home']
+            if home_score.isdigit():
+                home_score = int(home_score)
+            away_score = data[x]['away']
+            if away_score.isdigit():
+                away_score = int(away_score)
+            
+            result = {
+                'inning': int(x),
+                'home': home_score,
+                'away': away_score
+            }
             self.innings.append(result)
 
     def __iter__(self):

--- a/mlbgame/game.py
+++ b/mlbgame/game.py
@@ -277,15 +277,14 @@ class GameBoxScore(object):
         for x in sorted(data):
             # Cast score for each half-inning to `int` if score is a digit
             # For reference---examples of a blank score ('') appearing:
-            # 1. A team hasn't scored during the half-inning for an ongoing game
-            # 2. Home team does not bat during the bottom of the 9th because they have the lead
+            # 1. Team hasn't scored during the half-inning for an ongoing game
+            # 2. Home team does not bat during the bottom of the 9th
             home_score = data[x]['home']
             if home_score.isdigit():
                 home_score = int(home_score)
             away_score = data[x]['away']
             if away_score.isdigit():
                 away_score = int(away_score)
-            
             result = {
                 'inning': int(x),
                 'home': home_score,


### PR DESCRIPTION
I fixed the error in which I could not call `box_score()` during the top of an inning for an ongoing game. `box_score()` would result in throwing an error because `__init__` did not account for the score string for the top of an inning being a blank literal i.e. `''` and would attempt to cast `''` as an `int`. I also got rid of the `try` and `except` because it felt hacky and instead I check to see whether the score string returns `true` when `isdigit()` is called before deciding whether or not to cast the score string as an `int`.

Related issue that I opened: #127 